### PR TITLE
fix: headers 内无法显示标签、分类等页面

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,9 @@ menu:
   # 分类: /categories/ # 需要hexo new page categories
   # ...
 
+showInMenu:  # menu 中的哪些页面显示在首页中（“首页”必定显示）
+  - 文章
+
 footerLink: # 底部的链接自定义
   info: © 1949-2023 china  # info这个单词不能修改，不想使用可为空
   # 添加链接格式 举例

--- a/layout/_partial/header.ejs
+++ b/layout/_partial/header.ejs
@@ -5,14 +5,10 @@
 <% } %>
 <a class="index-logo" href="<%- url_for() %>"><%= config.title %></a>
 <div class="index-header">
-    首页&nbsp / &nbsp  
+    首页
     <% for (name in theme.menu) { %>
-        <% if(name == '文章' || name == '关于') { %>
-            <a href="<%- url_for(theme.menu[name]) %>"><%= name %></a>&nbsp / &nbsp 
-        <% } %>
-
-        <% if(name == 'Now') { %>
-            <a href="<%- url_for(theme.menu[name]) %>"><%= name %></a>
+        <% if(name !== '首页') { %>
+            &nbsp / &nbsp<a href="<%- url_for(theme.menu[name]) %>"><%= name %></a>
         <% } %>
     <% } %>
 </div>

--- a/layout/_partial/header.ejs
+++ b/layout/_partial/header.ejs
@@ -7,7 +7,7 @@
 <div class="index-header">
     首页
     <% for (name in theme.menu) { %>
-        <% if(name !== '首页') { %>
+        <% if(name !== '首页' && theme.showInMenu.includes(name)) { %>
             &nbsp / &nbsp<a href="<%- url_for(theme.menu[name]) %>"><%= name %></a>
         <% } %>
     <% } %>


### PR DESCRIPTION
原代码中写死了仅限“文章”、“关于”、“Now”这几个页面可以添加到 headers 里面，其它例如“标签”、“分类”或者自定义页面无法添加到 headers。在 `headers.ejs` 中修复这个问题。