### PR TITLE
improvement(layout): 改进网页title和subtitle分隔符问题

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -4,7 +4,7 @@
     <meta name="description" content="<%= page.title %>" />
     <meta name="hexo-theme-A4" content="<%= theme.version %>" />
     <link rel="alternate icon" type="image/webp" href="<%- url_for(theme.favicon) %>">
-    <title><%= config.title %> | <%= config.subtitle %></title>
+    <title><%= config.title + (config.subtitle ? ' | ' + config.subtitle : '') %></title>
 
     <% if(theme.cdn.enable && theme.cdn.choose != "") { %>
         <% if(theme.cdn.choose == "aliyun") { %>


### PR DESCRIPTION
改进config.yml中未填写subtitle时，网页title后面会有"|"问题。