### PR TITLE
fix:修复背景图片显示问题

### DIFF
--- a/layout/_partial/configcss/imageShow.ejs
+++ b/layout/_partial/configcss/imageShow.ejs
@@ -1,10 +1,18 @@
 <% if(theme.imageShow.enable) { %>
     <style>
-        body{
+        body {
             background-image: url(<%= theme.imageShow.background %>);
+            background-attachment: fixed;  /* 背景固定，不随页面滚动 */
+            background-repeat: no-repeat;  /* 防止背景图片重复 */
+            background-size: cover;       /* 背景自适应大小，覆盖整个背景 */
+            background-position: center;   /* 背景居中显示 */
         }
         .paper {
             background-image: url(<%= theme.imageShow.background %>);
+            background-attachment: fixed;  /* 背景固定，不随页面滚动 */
+            background-repeat: no-repeat;  /* 防止背景图片重复 */
+            background-size: cover;       /* 背景自适应大小，覆盖整个背景 */
+            background-position: center;   /* 背景居中显示 */
         }  
     </style>
 <% } %>


### PR DESCRIPTION
rt，修改前：
![QQ_1744724349135](https://github.com/user-attachments/assets/07e74cc6-187b-41cf-bfd3-86f1c5189367)

修改后：
![QQ_1744724327575](https://github.com/user-attachments/assets/7ed603e2-a233-4b1d-a19d-36408ea4cfc0)
将背景图片固定，防止缩放页面时，以及滚动页面时的不美观。