### PR TITLE
feat: 自定义base标签

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -184,4 +184,9 @@ comment:
 inject:
   css: css/custom.css # 找到该文件后，编写你的css样式，每个页面都会自动引入
 
+# 在<head>增加一个<base>元素，仅限有特殊需求者使用：https://developer.mozilla.org/zh-CN/docs/Web/HTML/Reference/Elements/base
+baseElement:
+  href:
+  target:
+
 version: v2.0.0

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -13,15 +13,15 @@
             <%- css('https://npm.elemecdn.com/hexo-theme-a4@latest/source/css/reset.css') %>
             <%- css('https://npm.elemecdn.com/hexo-theme-a4@latest/source/css/markdown.css') %>
             <%- css('https://npm.elemecdn.com/hexo-theme-a4@latest/source/css/fonts.css') %>
-            
+
             <!--注意：首页既不是post也不是page-->
             <% if((is_post() || is_page()) && theme.comment.enable && (!page.hasOwnProperty('comment') ||(page.hasOwnProperty('comment') && page.comment))) { %>
                 <%- css('https://npm.elemecdn.com/hexo-theme-a4@latest/source/css/waline.css') %>
             <% } %>
 
-            <%- css('https://npm.elemecdn.com/hexo-theme-a4@latest/source/css/ui.css') %> 
+            <%- css('https://npm.elemecdn.com/hexo-theme-a4@latest/source/css/ui.css') %>
             <%- css('https://npm.elemecdn.com/hexo-theme-a4@latest/source/css/style.css') %>
-    
+
             <!--返回顶部css-->
             <% if(theme.tool.returnToTop) { %>
                 <%- css('https://npm.elemecdn.com/hexo-theme-a4@latest/source/css/returnToTop.css') %>
@@ -36,15 +36,15 @@
             <%- css('https://jsd.onmicrosoft.cn/npm/hexo-theme-a4@latest/source/css/a11y-dark.min.css') %>
             <%- css('https://jsd.onmicrosoft.cn/npm/hexo-theme-a4@latest/source/css/reset.css') %>
             <%- css('https://jsd.onmicrosoft.cn/npm/hexo-theme-a4@latest/source/css/markdown.css') %>
-            <%- css('https://jsd.onmicrosoft.cn/npm/hexo-theme-a4@latest/source/css/fonts.css') %> 
+            <%- css('https://jsd.onmicrosoft.cn/npm/hexo-theme-a4@latest/source/css/fonts.css') %>
             <!--注意：首页既不是post也不是page-->
             <% if((is_post() || is_page()) && theme.comment.enable && (!page.hasOwnProperty('comment') ||(page.hasOwnProperty('comment') && page.comment))) { %>
                 <%- css('https://jsd.onmicrosoft.cn/npm/hexo-theme-a4@latest/source/css/waline.css') %>
             <% } %>
 
-            <%- css('https://jsd.onmicrosoft.cn/npm/hexo-theme-a4@latest/source/css/ui.css') %> 
+            <%- css('https://jsd.onmicrosoft.cn/npm/hexo-theme-a4@latest/source/css/ui.css') %>
             <%- css('https://jsd.onmicrosoft.cn/npm/hexo-theme-a4@latest/source/css/style.css') %>
-    
+
             <!--返回顶部css-->
             <% if(theme.tool.returnToTop) { %>
                 <%- css('https://jsd.onmicrosoft.cn/npm/hexo-theme-a4@latest/source/css/returnToTop.css') %>
@@ -60,15 +60,15 @@
             <%- css('https://jsd.cdn.zzko.cn/npm/hexo-theme-a4@latest/source/css/a11y-dark.min.css') %>
             <%- css('https://jsd.cdn.zzko.cn/npm/hexo-theme-a4@latest/source/css/reset.css') %>
             <%- css('https://jsd.cdn.zzko.cn/npm/hexo-theme-a4@latest/source/css/markdown.css') %>
-            <%- css('https://jsd.cdn.zzko.cn/npm/hexo-theme-a4@latest/source/css/fonts.css') %> 
+            <%- css('https://jsd.cdn.zzko.cn/npm/hexo-theme-a4@latest/source/css/fonts.css') %>
             <!--注意：首页既不是post也不是page-->
             <% if((is_post() || is_page()) && theme.comment.enable && (!page.hasOwnProperty('comment') ||(page.hasOwnProperty('comment') && page.comment))) { %>
                 <%- css('https://jsd.cdn.zzko.cn/npm/hexo-theme-a4@latest/source/css/waline.css') %>
             <% } %>
 
-            <%- css('https://jsd.cdn.zzko.cn/npm/hexo-theme-a4@latest/source/css/ui.css') %> 
+            <%- css('https://jsd.cdn.zzko.cn/npm/hexo-theme-a4@latest/source/css/ui.css') %>
             <%- css('https://jsd.cdn.zzko.cn/npm/hexo-theme-a4@latest/source/css/style.css') %>
-    
+
             <!--返回顶部css-->
             <% if(theme.tool.returnToTop) { %>
                 <%- css('https://jsd.cdn.zzko.cn/npm/hexo-theme-a4@latest/source/css/returnToTop.css') %>
@@ -84,13 +84,13 @@
             <%- css('https://npm.onmicrosoft.cn/hexo-theme-a4@latest/source/css/a11y-dark.min.css') %>
             <%- css('https://npm.onmicrosoft.cn/hexo-theme-a4@latest/source/css/reset.css') %>
             <%- css('https://npm.onmicrosoft.cn/hexo-theme-a4@latest/source/css/markdown.css') %>
-            <%- css('https://npm.onmicrosoft.cn/hexo-theme-a4@latest/source/css/fonts.css') %> 
+            <%- css('https://npm.onmicrosoft.cn/hexo-theme-a4@latest/source/css/fonts.css') %>
             <!--注意：首页既不是post也不是page-->
             <% if((is_post() || is_page()) && theme.comment.enable && (!page.hasOwnProperty('comment') ||(page.hasOwnProperty('comment') && page.comment))) { %>
                 <%- css('https://npm.onmicrosoft.cn/hexo-theme-a4@latest/source/css/waline.css') %>
             <% } %>
 
-            <%- css('https://npm.onmicrosoft.cn/hexo-theme-a4@latest/source/css/ui.css') %> 
+            <%- css('https://npm.onmicrosoft.cn/hexo-theme-a4@latest/source/css/ui.css') %>
             <%- css('https://npm.onmicrosoft.cn/hexo-theme-a4@latest/source/css/style.css') %>
 
             <!--返回顶部css-->
@@ -108,13 +108,13 @@
         <%- css('css/highlight/style1.css') %>
         <%- css('css/reset.css') %>
         <%- css('css/markdown.css') %>
-        <%- css('css/fonts.css') %> 
+        <%- css('css/fonts.css') %>
          <!--注意：首页既不是post也不是page-->
         <% if((is_post() || is_page()) && theme.comment.enable && (!page.hasOwnProperty('comment') ||(page.hasOwnProperty('comment') && page.comment))) { %>
             <%- css('css/waline.css') %>
         <% } %>
-        
-        <%- css('css/ui.css') %> 
+
+        <%- css('css/ui.css') %>
         <%- css('css/style.css') %>
 
         <% if(theme.tool.returnToTop) { %>
@@ -131,11 +131,23 @@
     <% if(theme.tool.returnToLast) { %>
         <%- css('css/returnToLastPage.css') %>
     <% } %>
-    
-   <%- css('css/lightgallery-bundle.min.css') %>
 
-   <% if(theme.inject.css) { %>
+    <%- css('css/lightgallery-bundle.min.css') %>
+
+    <% if(theme.inject.css) { %>
         <%- css(theme.inject.css) %>
     <% } %>
-    <link rel='stylesheet' href='https://chinese-fonts-cdn.deno.dev/packages/lxgwwenkai/dist/LXGWWenKai-Regular/result.css' /> 
+
+    <% if(theme.baseElement.href || theme.baseElement.target) { %>
+        <base
+            <% if(theme.baseElement.href) { %>
+                href="<%- theme.baseElement.href %>"
+            <% } %>
+            <% if(theme.baseElement.target) { %>
+                target="<%- theme.baseElement.target %>"
+            <% } %>
+        >
+    <% } %>
+
+    <link rel="stylesheet" href="https://chinese-fonts-cdn.deno.dev/packages/lxgwwenkai/dist/LXGWWenKai-Regular/result.css" />
 </head>


### PR DESCRIPTION
允许用户全局设定`<base href="xxx" target="xxx">`

比较小众的需求，在某些情况下非常有用。默认关闭。

<!--

这是为了绕过备案：理论上，国内备案后的主域名必须指向备案的服务商，指向一个GitHub Pages是不可以的。但事实上可以利用DNS的“隐性url功能”，靠一个iframe将用户引导至GitHub Pages，如http://nuistcpc.club就是这么做的。为了让我们可以便捷地前往GitHub Pages，使用<base>最方便了。

-->