### PR TITLE
feat: 在浏览器标签页显示文章标题

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -49,6 +49,7 @@ post:
 favicon: /img/favicon.webp # 默认方形头像
 isRoundedAvatar: false # 是否圆形头像
 isAvatarRotating: false # 圆形头像是否开启悬浮旋转
+displayTitleInTab: false # 是否在浏览器标签页显示文章标题
 
 # 是否启用一些特色工具 false | true
 tool:

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -4,7 +4,7 @@
     <meta name="description" content="<%= page.title %>" />
     <meta name="hexo-theme-A4" content="<%= theme.version %>" />
     <link rel="alternate icon" type="image/webp" href="<%- url_for(theme.favicon) %>">
-    <title><%= config.title + (config.subtitle ? ' | ' + config.subtitle : '') %></title>
+    <title><%= (theme.displayTitleInTab && page.title ? page.title + ' | ' : '') + config.title + (config.subtitle ? ' | ' + config.subtitle : '') %></title>
 
     <% if(theme.cdn.enable && theme.cdn.choose != "") { %>
         <% if(theme.cdn.choose == "aliyun") { %>


### PR DESCRIPTION
这样SEO更友好些。

![截图示例](https://github.com/user-attachments/assets/a330a99e-eaad-4e91-8dee-02adf4554e45)

左：开启此功能后没有标题的页面，如主页。

右：开启此功能后的文章。

默认关闭（同原先行为）。