### PR TITLE
fix 将字体 CSS 替换为更可靠的地址

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -137,5 +137,5 @@
    <% if(theme.inject.css) { %>
         <%- css(theme.inject.css) %>
     <% } %>
-    <link rel='stylesheet' href='https://chinese-fonts-cdn.deno.dev/packages/lxgwwenkai/dist/LXGWWenKai-Regular/result.css' /> 
+    <link rel='stylesheet' href='https://cdn.jsdelivr.net/npm/@chinese-fonts/lxgwwenkai@3.0.0/dist/LXGWWenKai-Regular/result.css' /> 
 </head>


### PR DESCRIPTION
 源地址经常出现访问受限，无法访问的问题