### PR TITLE
添加ICP与公安备案号悬挂功能

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -39,6 +39,16 @@ footerLink: # 底部的链接自定义
   # 支持: /support/ # 需要hexo new page support
   # ...
 
+# 网站备案信息
+beian:
+  enable: true # 是否启用备案号
+  icp: "京ICP备xxxxxxxx号" # 备案号
+  url: "https://beian.miit.gov.cn/" # 备案查询链接
+  gongan: # 公安备案信息
+    enable: false # 是否启用公安备案
+    code: "京公网安备xxxxxxxx号" # 公安备案号
+    url: "https://beian.miit.gov.cn/" # 公安备案查询链接
+
 post:
   footer: 🌊看过大海的人不会忘记海的广阔🌊
   themeInfo: true # 是否开启底部右侧声明本站信息

--- a/layout/_partial/footer.ejs
+++ b/layout/_partial/footer.ejs
@@ -1,7 +1,7 @@
 <div class="footer">
     <% if(path != 'index.html') { %>
         <span> 
-            <%= theme.footerLink.info %> 
+            <%= theme.footerLink.info %>
 
             <% for (name in theme.footerLink) { %>
                 <% if(name != 'info') { %>
@@ -44,8 +44,24 @@
                 <span class="index-footer-last-span"><%= theme.index.footer %></span>
             <% } %>
         <% } %>
+        <% if(theme.beian.enable) { %>
+            <span class="footer-last-span-right">
+                <a href="<%= theme.beian.url %>" target="_blank" rel="noopener noreferrer"><%= theme.beian.icp %></a>
+                <% if(theme.beian.gongan.enable) { %>
+                    | <a href="<%= theme.beian.gongan.url %>" target="_blank" rel="noopener noreferrer"><%= theme.beian.gongan.code %></a>
+                <% } %>
+            </span>
+        <% } %>
     <% } else { %>
             <span><%= theme.post.footer %></span>
+            <% if(theme.beian.enable) { %>
+                <span class="footer-last-span-right">
+                    <a href="<%= theme.beian.url %>" target="_blank" rel="noopener noreferrer"><%= theme.beian.icp %></a>
+                    <% if(theme.beian.gongan.enable) { %>
+                        | <a href="<%= theme.beian.gongan.url %>" target="_blank" rel="noopener noreferrer"><%= theme.beian.gongan.code %></a>
+                    <% } %>
+                </span>
+            <% } %>
             <% if(theme.post.themeInfo) { %>
                 <span class="footer-last-span-right"><i>本站由<a href="https://hexo.io/zh-cn/index.html">Hexo</a>驱动｜使用<a href="https://github.com/HiNinoJay/hexo-theme-A4">Hexo-theme-A4</a>主题</i></span>
             <% } %>


### PR DESCRIPTION
在 _config.yml 中添加 ICP 配置，并在页脚中显示。新配置包含 enable、ICP、url 以及一个嵌套的 gongan 块（enable、code、url）。更新 layout/_partial/footer.ejs，使其在启用后，在首页和其他页面上根据条件显示 ICP 链接（以及可选的公安备案）。